### PR TITLE
Fix crash caused by comparing None to int() after settings module output None-type to "limit" in config.json

### DIFF
--- a/oscrmodules/misc.py
+++ b/oscrmodules/misc.py
@@ -73,7 +73,7 @@ def getConfig(gvars):
 
 def calculateEssentials(gvars):
     
-    if gvars.config["limit"] >= 1000 or not str(gvars.config["limit"]).isnumeric():
+    if not str(gvars.config["limit"]).isnumeric() or gvars.config["limit"] >= 1000:
         gvars.config["limit"] = None
     try:
         gvars.config["cutoffSec"] = gvars.config["cutoff"]*gvars.config["cutoffUnit"]


### PR DESCRIPTION
Fixes #34 