### PR TITLE
2.0.0 patch3 issue 61

### DIFF
--- a/oscr
+++ b/oscr
@@ -74,7 +74,7 @@ elif "--credits" in sys.argv:
 elif "--show-config" in sys.argv:
     from oscrmodules import gvars, misc
     gvars = gvars.initialiseGlobals(gvars.version)
-    gvars = misc.getConfig(gvars, False)
+    gvars.config = misc.getConfig(gvars, False)
     for i in gvars.config:
         print(f"{i}: {gvars.config[i]}")
     sys.exit(0)

--- a/oscrmodules/gvars.py
+++ b/oscrmodules/gvars.py
@@ -21,7 +21,7 @@ from os.path import expanduser
 
 global version
 
-version = "2.0.0-dev2-20210211"
+version = "2.0.0-dev3-20210214"
 
 class Globals():
     def __init__(self, version):

--- a/oscrmodules/misc.py
+++ b/oscrmodules/misc.py
@@ -93,7 +93,7 @@ def getConfig(gvars, essentialsNeeded):
     if essentialsNeeded:
         return calculateEssentials(gvars)
     else:
-        return gvars
+        return gvars.config
 
 # Performs any necessary one-time calculations and changes relating to the config
 def calculateEssentials(gvars):

--- a/oscrmodules/settings.py
+++ b/oscrmodules/settings.py
@@ -147,6 +147,7 @@ def editConfig(gvars):
                     return True
                 try:
                     gvars.config[key] = int(value)
+                    break
                 except TypeError as e:
                     print(f"{e} - Not an integer.")
 
@@ -158,6 +159,7 @@ def editConfig(gvars):
                     return True
                 try:
                     gvars.config[key] = json.loads(value.lower())
+                    break
                 except TypeError as e:
                     print(f"{e} - Not a boolean.")
 
@@ -179,8 +181,6 @@ def editConfig(gvars):
             ]
             gvars.config[key] = newUnit
 
-    gvars.config.pop("cutoffSec")
-    gvars.config.pop("waitTime")
     outConfig = {}
     outConfig["config"] = []
     outConfig["config"].append(gvars.config)


### PR DESCRIPTION
Fixes #61 for 2.0.0: Attempting to update integer or boolean keys in the settings menu causes an infinite loop.